### PR TITLE
9 add built in prompt templates

### DIFF
--- a/config/ollamec.config.ts
+++ b/config/ollamec.config.ts
@@ -19,6 +19,9 @@ export const TOKENS = {
 
   /** Transport mechanism for message delivery (e.g., CLI, SSE) */
   Transport: Symbol('Transport'),
+
+  /** A registry of built-in prompt templates (used by PromptManager) */
+  PromptTemplates: Symbol('PromptTemplates'),
 } as const;
 
 /**
@@ -42,7 +45,23 @@ export function registerClass<T>(
 }
 
 /**
- * Internal helper type for class constructors used in DI.
+ * Registers a plain value or object instance to the given DI token.
+ * Useful for injecting constants or registries like built-in templates.
+ *
+ * @param token - DI symbol from `TOKENS`
+ * @param value - The instance or literal value to bind
+ */
+export function registerValue<T>(token: OllamecToken, value: T): void {
+  container.registerInstance<T>(token, value);
+}
+
+/**
+ * Generic class constructor type used for dependency injection.
+ *
+ * Represents any class that can be instantiated with arbitrary arguments
+ * and returns an instance of type `T`.
+ *
+ * This allows `registerClass()` to accept a wide range of valid implementations.
  */
 // biome-ignore lint/suspicious/noExplicitAny: necessary to support DI constructor flexibility
 type Constructor<T> = new (...args: any[]) => T;

--- a/core/registerBuiltIns.ts
+++ b/core/registerBuiltIns.ts
@@ -53,5 +53,11 @@ export function registerBuiltInImplementations(): void {
   /**
    * Register the built-in prompt templates registry.
    */
+  if (
+    !builtInPromptTemplates ||
+    Object.keys(builtInPromptTemplates).length === 0
+  ) {
+    throw new Error('Built-in prompt templates are missing or empty');
+  }
   registerValue(TOKENS.PromptTemplates, builtInPromptTemplates);
 }

--- a/core/registerBuiltIns.ts
+++ b/core/registerBuiltIns.ts
@@ -1,10 +1,15 @@
-import { TOKENS, registerClass } from '../config/ollamec.config.ts';
+import {
+  TOKENS,
+  registerClass,
+  registerValue,
+} from '../config/ollamec.config.ts';
 
 import { DefaultPromptManager } from '@ollamec/framework/core/DefaultPromptManager.ts';
 import { DefaultToolManager } from '@ollamec/framework/core/DefaultToolManager.ts';
 import { DefaultLLMClient } from '@ollamec/framework/llm/DefaultLLMClient';
 import { DefaultTransport } from '@ollamec/framework/mcp/DefaultTransport';
 import { InMemorySlidingMemory } from '@ollamec/framework/memory/InMemorySlidingMemory.ts';
+import { builtInPromptTemplates } from '@ollamec/framework/prompts/builtins';
 
 /**
  * Registers the default Ollamec strategy implementations into the global DI container.
@@ -44,4 +49,9 @@ export function registerBuiltInImplementations(): void {
    * Register the default transport layer, which simulates LLM interaction.
    */
   registerClass(TOKENS.Transport, DefaultTransport);
+
+  /**
+   * Register the built-in prompt templates registry.
+   */
+  registerValue(TOKENS.PromptTemplates, builtInPromptTemplates);
 }

--- a/prompts/PromptTemplateInterface.ts
+++ b/prompts/PromptTemplateInterface.ts
@@ -1,0 +1,16 @@
+/**
+ * Represents a reusable system prompt template.
+ *
+ * Used by the PromptManager to inject predefined behavior
+ * into the initial message flow.
+ */
+export interface PromptTemplateInterface {
+  /** Unique identifier for the template */
+  name: string;
+
+  /** Short description of the template’s purpose */
+  description: string;
+
+  /** The system prompt string used to guide the LLM */
+  systemPrompt: string;
+}

--- a/prompts/builtins.ts
+++ b/prompts/builtins.ts
@@ -2,12 +2,18 @@ import type { PromptTemplateInterface } from './PromptTemplateInterface.ts';
 import { formatAsJson } from './format-as-json.ts';
 import { summarizeText } from './summarize-text.ts';
 
+/** Internal constant keys for built-in prompt templates. */
+const TEMPLATE_KEYS = {
+  FORMAT_AS_JSON: 'format-as-json',
+  SUMMARIZE_TEXT: 'summarize-text',
+} as const;
+
 /**
  * A registry of built-in prompt templates shipped with Ollamec.
  *
  * These templates can be resolved via DI and used by PromptManager.
  */
 export const builtInPromptTemplates: Record<string, PromptTemplateInterface> = {
-  [summarizeText.name]: summarizeText,
-  [formatAsJson.name]: formatAsJson,
+  [TEMPLATE_KEYS.SUMMARIZE_TEXT]: summarizeText,
+  [TEMPLATE_KEYS.FORMAT_AS_JSON]: formatAsJson,
 };

--- a/prompts/builtins.ts
+++ b/prompts/builtins.ts
@@ -1,0 +1,13 @@
+import type { PromptTemplateInterface } from './PromptTemplateInterface.ts';
+import { formatAsJson } from './format-as-json.ts';
+import { summarizeText } from './summarize-text.ts';
+
+/**
+ * A registry of built-in prompt templates shipped with Ollamec.
+ *
+ * These templates can be resolved via DI and used by PromptManager.
+ */
+export const builtInPromptTemplates: Record<string, PromptTemplateInterface> = {
+  [summarizeText.name]: summarizeText,
+  [formatAsJson.name]: formatAsJson,
+};

--- a/prompts/format-as-json.ts
+++ b/prompts/format-as-json.ts
@@ -1,0 +1,12 @@
+import type { PromptTemplateInterface } from './PromptTemplateInterface.ts';
+
+/**
+ * Built-in prompt template: Format as JSON
+ *
+ * Reformats raw input into a structured JSON object.
+ */
+export const formatAsJson: PromptTemplateInterface = {
+  name: 'format-as-json',
+  description: 'Reformats input into structured JSON format.',
+  systemPrompt: '', // Will be filled in during Step 3
+};

--- a/prompts/format-as-json.ts
+++ b/prompts/format-as-json.ts
@@ -8,5 +8,7 @@ import type { PromptTemplateInterface } from './PromptTemplateInterface.ts';
 export const formatAsJson: PromptTemplateInterface = {
   name: 'format-as-json',
   description: 'Reformats input into structured JSON format.',
-  systemPrompt: '', // Will be filled in during Step 3
+  systemPrompt: `You are a structured output generator.
+When the user provides unstructured information, return a well-formed JSON object.
+Only return raw JSON with no explanations or formatting.`,
 };

--- a/prompts/summarize-text.ts
+++ b/prompts/summarize-text.ts
@@ -1,0 +1,12 @@
+import type { PromptTemplateInterface } from './PromptTemplateInterface.ts';
+
+/**
+ * Built-in prompt template: Summarize Text
+ *
+ * Produces a concise summary from a block of input text.
+ */
+export const summarizeText: PromptTemplateInterface = {
+  name: 'summarize-text',
+  description: 'Produces a concise summary from input text.',
+  systemPrompt: '', // Will be filled in during Step 3
+};

--- a/prompts/summarize-text.ts
+++ b/prompts/summarize-text.ts
@@ -9,6 +9,10 @@ export const summarizeText: PromptTemplateInterface = {
   name: 'summarize-text',
   description: 'Produces a concise summary from input text.',
   systemPrompt: `You are a helpful assistant that summarizes information clearly and concisely.
-Focus only on the most important details. Avoid repetition or filler.
-Respond with a plain-language summary of the user's message.`,
+Follow these requirements:
+1. Create a summary of 2-3 sentences maximum
+2. Focus on key action items, decisions, and main concepts
+3. Maintain the original tone (technical, casual, formal)
+4. Preserve any critical numerical data or statistics
+Respond with a plain-language summary following these guidelines.`,
 };

--- a/prompts/summarize-text.ts
+++ b/prompts/summarize-text.ts
@@ -8,5 +8,7 @@ import type { PromptTemplateInterface } from './PromptTemplateInterface.ts';
 export const summarizeText: PromptTemplateInterface = {
   name: 'summarize-text',
   description: 'Produces a concise summary from input text.',
-  systemPrompt: '', // Will be filled in during Step 3
+  systemPrompt: `You are a helpful assistant that summarizes information clearly and concisely.
+Focus only on the most important details. Avoid repetition or filler.
+Respond with a plain-language summary of the user's message.`,
 };

--- a/tests/unit/config/di-resolution.unit.test.ts
+++ b/tests/unit/config/di-resolution.unit.test.ts
@@ -9,6 +9,7 @@ import type { PromptManagerInterface } from '@ollamec/framework/core/interfaces/
 import type { ToolManagerInterface } from '@ollamec/framework/core/interfaces/ToolManagerInterface.ts';
 import { registerBuiltInImplementations } from '@ollamec/framework/core/registerBuiltIns.ts';
 import { InMemorySlidingMemory } from '@ollamec/framework/memory/InMemorySlidingMemory.ts';
+import type { PromptTemplateInterface } from '@ollamec/framework/prompts/PromptTemplateInterface';
 
 describe('Dependency Injection Container', () => {
   beforeAll(() => {
@@ -35,6 +36,17 @@ describe('Dependency Injection Container', () => {
       TOKENS.ToolManager
     );
     expect(toolManager).toBeInstanceOf(DefaultToolManager);
+  });
+
+  it('should resolve PromptTemplates registry with expected entries', () => {
+    const templates = container.resolve<
+      Record<string, PromptTemplateInterface>
+    >(TOKENS.PromptTemplates);
+
+    expect(templates).toBeDefined();
+    expect(typeof templates).toBe('object');
+    expect(templates['summarize-text']).toBeDefined();
+    expect(templates['format-as-json']).toBeDefined();
   });
 
   // Additional DI resolution tests (LLMClient, PromptManager, etc) can be added here

--- a/tests/unit/prompts/builtins.unit.test.ts
+++ b/tests/unit/prompts/builtins.unit.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test';
+import { builtInPromptTemplates } from '@ollamec/framework/prompts/builtins.ts';
+
+describe('builtInPromptTemplates', () => {
+  it('should include summarize-text template', () => {
+    const tpl = builtInPromptTemplates['summarize-text'];
+    expect(tpl).toBeDefined();
+    expect(tpl.name).toBe('summarize-text');
+    expect(typeof tpl.systemPrompt).toBe('string');
+    expect(tpl.systemPrompt.length).toBeGreaterThan(0);
+  });
+
+  it('should include format-as-json template', () => {
+    const tpl = builtInPromptTemplates['format-as-json'];
+    expect(tpl).toBeDefined();
+    expect(tpl.name).toBe('format-as-json');
+    expect(typeof tpl.systemPrompt).toBe('string');
+    expect(tpl.systemPrompt.length).toBeGreaterThan(0);
+  });
+
+  it('should expose exactly two templates', () => {
+    expect(Object.keys(builtInPromptTemplates)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add built-in prompt templates to the core Ollamec framework for dependency injection and easy access by the `PromptManager`.

### Why are these changes being made?
The addition of built-in prompt templates, such as 'format-as-json' and 'summarize-text', improves functionality by providing reusable templates that streamline the process of injecting predefined behavior into the system. These templates help maintain structure and consistency across different implementations, which enhances usability and reduces repetitive configurations. The changes ensure that the templates are correctly registered and accessible through the dependency injection system with associated tests confirming the setup.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->