### PR TITLE
docs: added post mvp planning docs

### DIFF
--- a/project-docs/framework-layout.md
+++ b/project-docs/framework-layout.md
@@ -1,0 +1,89 @@
+# Ollamec Framework Layout
+
+This document provides a structural overview of the Ollamec framework and how developers can integrate and extend it within their own applications. It complements the [Ollamec Overview](./ollamec-overview.md), which explains the architectural intent, design principles, and client orchestration model.
+
+---
+
+## 📁 Core Framework Layout (Ollamec)
+
+This is the internal folder structure of the Ollamec project itself:
+
+```
+ollamec/
+├── bin/                            # Thin entrypoints (e.g., `ollamec.ts` CLI launcher)
+├── config/                         # DI container setup, tokens, and registration helpers
+├── core/                           # Interfaces and default implementations (Prompt, Memory, LLM, etc.)
+├── llm/                            # Built-in LLM clients (e.g., `DefaultLLMClient`, `OllamaClient`)
+├── memory/                         # Built-in memory strategies (e.g., `InMemorySlidingMemory`)
+├── prompts/                        # Built-in prompt templates and registry loader
+├── tests/                          # Bun-based unit and integration tests
+├── tsconfig.json                   # TS config for the framework
+├── bunfig.toml                     # Bun project configuration
+└── .config/*                       # Biome, Lefthook, and commit-lint config files
+```
+
+### Notes:
+
+- `cli/` and `commander` usage is being phased out. The CLI will become a thin launcher around `OllamecClient`.
+- `plugins/` and `custom/` have been deprecated in favor of DI-based extension through user projects.
+
+---
+
+## 🧑‍💻 Developer Project Layout (Using Ollamec)
+
+Here’s how a consumer of the Ollamec framework might structure their project:
+
+```
+my-ollamec-app/
+├── src/
+│   ├── config/                     # Contains `ollamec.config.ts` for registering custom strategies
+│   ├── llm/                        # Custom LLM client implementations
+│   ├── memory/                     # Custom memory strategies (if any)
+│   ├── prompts/                    # Custom prompt templates (JSON or modules)
+│   ├── tools/                      # Custom tool functions or dispatchers
+│   └── index.ts                    # Entry point — instantiates and runs `OllamecClient`
+├── tests/                          # Unit, integration, or end-to-end tests
+├── .biomerc.json                   # BiomeJS configuration
+├── .lefthook.yml                   # Lefthook hooks (e.g., pre-commit)
+├── .commitlintrc.json              # Conventional commit configuration
+├── tsconfig.json                   # App-wide TypeScript config
+├── bunfig.toml                     # Bun project config
+└── README.md                       # Project-specific documentation
+```
+
+### Notes:
+
+- All customization is handled via `ollamec.config.ts` or subclassing `BaseOllamecClient`
+- Developers can override any default behavior by binding their own class to a DI token
+- CLI execution is optional — developers can run Ollamec fully programmatically
+
+---
+
+## 🤖 Integration Workflow
+
+> For an explanation of how this structure maps to runtime behavior and design patterns, see [ollamec-overview.md](./ollamec-overview.md).
+
+
+1. **Install Ollamec via Bun**
+
+   ```sh
+   bun add ollamec
+   ```
+
+2. **Create **`` Register custom implementations using `registerClass()` or `registerValue()`
+
+3. **Subclass or Instantiate **``
+
+   ```ts
+   const client = new OllamecClient({ sessionId: 'abc' });
+   const result = await client.chat({ input: 'hello' });
+   ```
+
+4. **Write Custom Tools, Memory Strategies, and Prompt Templates**
+
+5. **Write Tests to Verify Extension Points**
+
+---
+
+This document is intended as a quick reference for onboarding contributors and app developers. For deeper context on architecture, refer to `ollamec-overview.md`.
+

--- a/project-docs/ollamec-overview.md
+++ b/project-docs/ollamec-overview.md
@@ -1,0 +1,156 @@
+# Ollamec Overview
+
+Ollamec is a lightweight backend framework for building MCP-compliant developer agents and orchestration systems. It provides dependency-injected components for working with LLMs, memory stores, tools, and structured prompt pipelines.
+
+---
+
+## Goals
+
+- Provide a minimal, dependency-injected backend framework for building LLM-driven agents
+- Emphasize tool augmentation, memory layering, and structured prompting
+- Support both local-first CLI usage and remote API integration
+- Make it easy for developers to swap in their own strategies without rewriting core logic
+
+---
+
+## The Problem We're Solving
+
+Existing agent frameworks often force developers into specific patterns, such as:
+- Long-running HTTP servers
+- Fully-coupled memory and prompt strategies
+- Non-extensible tool management
+
+Ollamec lets developers build their own agents using composable, DI-powered parts — not a monolith.
+
+---
+
+## What Exists vs What We're Building
+
+| Existing Stack         | Ollamec's Direction                                   |
+|------------------------|--------------------------------------------------------|
+| LangChain             | Heavy, opinionated, runtime-coupled                   |
+| Semantic Kernel       | API-driven orchestration via plugins                  |
+| OpenLLM               | Server-focused, LLM runtime abstraction               |
+| Ollama                | Model runner, not an orchestrator                     |
+
+---
+
+## Developer Experience
+
+- Install and run with minimal configuration
+- Use default strategies or swap in your own
+- Extend core interfaces like `PromptManagerInterface`, `ToolManagerInterface`, etc.
+- Compose orchestration flows using a single injectable client
+
+```ts
+const ollamec = new OllamecClient({ sessionId: 'xyz' });
+const result = await ollamec.chat({ input: 'What is the weather today?' });
+```
+
+---
+
+## Dependency Injection and Configuration
+
+Ollamec uses `tsyringe` to provide local, override-friendly dependency injection. Each `OllamecClient` owns its own container and resolves:
+
+- `PromptManagerInterface`
+- `LLMClientInterface`
+- `ToolManagerInterface`
+- `MemoryStoreInterface`
+- `PromptTemplates`
+
+This makes it easy to override behavior or create scoped clients without global side effects.
+
+---
+
+## Tech Stack
+
+- **Language:** TypeScript
+- **Runner:** Bun
+- **DI:** tsyringe
+- **Testing:** Bun test
+- **Prompt Format:** OpenAI-style message arrays
+- **Core Interfaces:** PromptManagerInterface, ToolManagerInterface, LLMClientInterface, MemoryStoreInterface, TransportInterface
+
+---
+
+## Key Concepts
+
+See the sections below for how DI, prompt formatting, tools, and memory strategies work together in the client runtime.
+
+---
+
+## Core Features
+
+Ollamec exposes a set of injectable strategies and runtime utilities that developers can compose as needed.
+
+See [framework-layout.md](./framework-layout.md) for a breakdown of how these are organized in the filesystem.
+
+---
+
+## OllamecClient Architecture
+
+OllamecClient is the central orchestrator for MCP-style agents. It abstracts away CLI logic and allows direct control via code. Developers can:
+
+- Extend `BaseOllamecClient` to create custom clients
+- Use the default `OllamecClient` for plug-and-play usage
+- Register custom tools, memory strategies, or prompt templates via DI
+
+Each client instance owns its own DI container, allowing scoped overrides.
+
+---
+
+## Prompt Composition
+
+Prompt construction is handled by the `PromptManagerInterface`. It accepts a `PromptContext` containing:
+
+- Raw user input
+- Tool response objects
+- Previously stored memory messages
+
+`BaseOllamecClient` is responsible for injecting system prompts at the start of a session. These come from the `PromptTemplates` registry (injected via DI).
+
+---
+
+## Memory Model
+
+Memory is no longer limited to load/save. Ollamec supports a session-aware lifecycle:
+
+```ts
+connect(session: MemorySession): Promise<boolean>
+load(options?: { limit?: number }): Promise<ChatMessage[]>
+append(messages: ChatMessage[]): Promise<boolean>
+```
+
+This allows richer implementations and improves safety for distributed contexts.
+
+---
+
+## LLMClient Expectations
+
+The `LLMClientInterface` should implement:
+
+```ts
+chat(request: ChatRequest): Promise<ChatResponse>
+```
+
+The response must include at least one message (`choices[0].message`).
+
+---
+
+
+
+## Use Cases
+
+> See also: [framework-layout.md](./framework-layout.md) for how these use cases map to directory and runtime structure.
+
+
+- Local-first CLI agents that call local models or Ollama
+- Serverless API agents for OpenAI/Claude
+- Streaming LLM responses with intermediate tool augmentation
+- Custom agents for automating task execution or search
+
+---
+
+Ollamec aims to be the backend LLM runtime you reach for when you want full control over tools, memory, and prompt logic — but don’t want to rebuild the framework every time.
+

--- a/project-docs/post-mvp-plan.md
+++ b/project-docs/post-mvp-plan.md
@@ -1,0 +1,207 @@
+# 🔧 Ollamec Post-MVP Planning Tracker
+
+This document tracks issues and inconsistencies across the orchestration flow, DI setup, and interface implementations in the Ollamec CLI and framework internals. Each entry should be addressed to ensure stable and predictable behavior across prompt building, tool execution, memory usage, and LLM integration.
+
+---
+
+## Major Changes
+
+### `MemoryStoreInterface` needs expanded lifecycle control
+
+- Symptom: Memory implementations have unclear behavior around session lifecycle, causing brittle assumptions (e.g., `load()` throws if session isn't initialized).
+- Proposal:
+    - Replace existing `load/save` contract with a more expressive lifecycle model:
+      ```ts
+      connect(session: MemorySession): Promise<boolean>;
+      load(options: { limit?: number; offset?: number }): Promise<ChatMessage[]>;
+      append(messages: ChatMessage[]): Promise<boolean>;
+      ```
+    - Benefits:
+        - Enables richer memory implementations (streaming, persistent, remote)
+        - Makes it explicit when memory sessions begin
+        - Avoids `load()` failures on uninitialized state
+
+### `Refactor MemoryStoreInterface`
+
+- Symptom: Memory implementations have unclear behavior around session lifecycle, causing brittle assumptions (e.g., `load()` throws if session isn't initialized).
+- Proposal:
+    - Replace existing `load/save` contract with a more expressive lifecycle model:
+      ```ts
+      connect(session: MemorySession): Promise<boolean>;
+      load(options: { limit?: number; offset?: number }): Promise<ChatMessage[]>;
+      append(messages: ChatMessage[]): Promise<boolean>;
+      ```
+    - Include diagnostics and fail-safe behavior in `InMemorySlidingMemory`
+    - Benefits:
+        - Enables richer memory implementations (streaming, persistent, remote)
+        - Makes it explicit when memory sessions begin
+        - Avoids `load()` failures on uninitialized state
+        - Improves developer experience when testing custom clients
+
+---
+
+### `ToolManagerInterface.runTools()`
+
+- Expected Output: Should return name-keyed outputs for prompt injection.
+- Issue: Too loosely defined — `toolResults` format isn't ideal for DI or prompt usage.
+- Fix Plan:
+    - Keep current return type (`ToolResult[]`) but introduce a utility function
+    - Create `extractToolResponses()` in `core/utils/toolHelpers.ts` to convert `ToolResult[]` to `Record<string, unknown>` for use in `PromptContext`
+    - Avoids interface churn while making prompt integration easier and testable
+
+### `PromptManagerInterface.buildPrompt()`
+
+- Issue: Doesn’t specify default/system message behavior
+- Decision: System prompt injection should be the responsibility of the `OllamecClient`, not `PromptManager`.
+- Rationale: `PromptManager` should remain focused purely on transforming `PromptContext` into a structured prompt. Session state, system message injection, and prompt seeding logic belong to the orchestration layer (`OllamecClient`).
+- Fix Plan:
+    - Remove responsibility for system prompt injection from `PromptManager`
+    - `OllamecClient` should detect if session is new (e.g., `chatHistory.length === 0`) and prepend a named system prompt from `TOKENS.PromptTemplates`
+    - `PromptManager.buildPrompt()` should remain deterministic: history → tools → user input
+
+### `LLMClientInterface.chat()`
+
+- Issue: Assumes OpenAI-style output with `choices[0].message`
+- Fix Plan:
+    - Add contract enforcement for `choices.length >= 1`
+    - Normalize interface to support single-message shorthand
+
+---
+
+### Create `OllamecClient`
+
+- Objective: Define a structured, developer-friendly entrypoint for programmatic and CLI-based agents, and phase out the `commander`-based CLI system.
+  Define a structured, developer-friendly entrypoint for programmatic and CLI-based agents.
+- Scope:
+    - Create `OllamecClientInterface`: contract for agents that wish to handle input/session orchestration
+    - Create `BaseOllamecClient`: handles tool execution, prompt building, memory, LLM dispatch
+    - Create default `OllamecClient`: pre-configured with default strategies for quick usage
+    - Move orchestration logic out of CLI and into `BaseOllamecClient`, removing `commander` entirely
+- Rationale:
+    - Promotes clean separation between orchestration and invocation layers
+    - Gives developers flexibility to subclass, replace, or extend
+    - Removes dependency on CLI frameworks, and promotes `OllamecClient` as the primary orchestration interface
+
+---
+
+## 🧱 Developer-Facing OllamecClient Design Direction
+
+### Built-in Prompt Template Handling
+
+- BaseOllamecClient should resolve a named startup template from `TOKENS.PromptTemplates`
+
+- This should be injected into the message flow if the session is new (e.g., empty memory)
+
+- PromptManager should **not** be responsible for loading templates — it should receive them via `PromptContext`
+
+- This enables:
+
+    - Developer-defined onboarding/system prompts
+    - Clear separation of template registry vs. prompt construction logic
+
+- Developers should be able to subclass a base `OllamecClient` and customize the following:
+
+    - MemoryStore implementation
+    - LLMClientInterface implementation (e.g. local, OpenAI, Claude)
+    - Initial system prompt (via named entry in `PromptTemplates`)
+    - MCP tools to register in DI
+
+- Each `OllamecClient` instance should own its own DI container (not global), initialized on construction.
+
+- That container should be responsible for registering or swapping in:
+
+    - PromptManager
+    - ToolManager
+    - MemoryStore
+    - LLMClientInterface
+    - PromptTemplates and session config (optional)
+
+- The base `.chat()` method should orchestrate the standard flow:
+
+    - Load memory
+    - Run tools
+    - Build prompt
+    - Send to LLMClient
+    - Save output to memory
+
+- This enables:
+
+```ts
+const ollamec = new OllamecClient({ sessionId: 'thread-abc' });
+const response = await ollamec.chat({ input: 'Who won the game?' });
+```
+
+- Developers may extend `BaseOllamecClient` to build richer clients:
+
+```ts
+class CustomOllamecClient extends BaseOllamecClient {
+  async askOpenAI(input: string) { ... }
+  async askLlama(input: string) { ... }
+}
+```
+
+- This encourages a flexible, testable, injectable agent architecture with DI-scoped strategies and zero reliance on global registration.
+
+---
+
+> This file is canonical for tracking issues in the orchestration layer. All inconsistencies should be logged here before patches.
+
+---
+
+## 📌 Task Order
+
+Defines the preferred sequence for tackling post-mvp issues based on architectural dependencies and build confidence:
+
+1. **Improve Error Diagnostics in Orchestration**
+2. **Add extractToolResponses() utility**
+3. **Refactor MemoryStoreInterface**
+4. **Harden LLMClientInterface.chat() contract**
+5. **Implement OllamaClient**
+6. **Create OllamecClient**
+
+## 🔄 Milestone Changes
+
+### Milestone Renaming
+
+- The `v1` milestone has been renamed to **post-mvp**
+- The `v2` milestone has been renamed to **v1**
+
+
+
+## 📋 New Issues for new milestone post-mvp
+
+These issues should be created and assigned to the `post-mvp` milestone based on the Major Changes section above:
+
+1. **Refactor MemoryStoreInterface**
+
+    - Redesign the core memory contract with `connect/load/append`
+    - Add diagnostics and fail-safes to `InMemorySlidingMemory`
+
+2. **Create OllamecClient**
+
+    - Create `OllamecClientInterface`, `BaseOllamecClient`, and default `OllamecClient`
+    - Move CLI orchestration logic into `BaseOllamecClient`
+    - Phase out `commander`
+
+3. **Add extractToolResponses() utility**
+
+    - Add helper to convert `ToolResult[]` → `Record<string, unknown>` for prompt injection
+
+4. **Harden LLMClientInterface.chat() contract**
+
+    - Ensure `choices.length >= 1`
+    - Normalize single-message response fallback behavior
+
+5. **Improve Error Diagnostics in Orchestration**
+
+    - Add try/catch handling, verbose logs, and `--debug` support for dev UX
+    - Introduce a centralized logger to be used by orchestration, tools, and memory
+    - Ensure the logger supports configurable levels (info, debug, error) and optional CLI colorization
+
+These updates reflect milestone reassignments or removals made after initial issue triage:
+
+- ✅ Closed: **#8 Bootstrap Ollamec CLI** (CLI orchestration now moved into `OllamecClient`)
+- 🔄 Moved to post-mvp: **#12 Implement OllamaClient** (core runtime requirement)
+
+> Additional issues from this doc will be added to the `post-mvp` milestone where appropriate.
+


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add comprehensive documentation for post-MVP planning, including framework layout, architectural overview, and detailed planning for future iterations of the Ollamec framework.

### Why are these changes being made?

The changes provide essential guidance for developers to understand the current architecture, integrate and extend the Ollamec framework effectively, and track planned improvements. This documentation serves as a foundation for navigating and contributing to the project as it moves beyond the MVP stage, ensuring a structured and transparent development process.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->